### PR TITLE
feat: Design main interface with writing and file areas

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,13 @@ import { checkForAppUpdates } from '@/lib/updater';
 import { invoke } from '@tauri-apps/api/core';
 import { message } from '@tauri-apps/plugin-dialog';
 import { useTauriAppVersion, useTauriOsType } from '@/hooks/useTauriApp';
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@/components/ui/resizable';
+import { FileArea } from '@/components/file-area';
+import { WritingArea } from '@/components/writing-area';
 
 export default function Home() {
   const appVersion = useTauriAppVersion();
@@ -218,133 +225,16 @@ export default function Home() {
         </aside>
 
         {/* 主内容区 */}
-        <main className='flex-1 overflow-auto p-8'>
-          <div className='mx-auto max-w-3xl'>
-            <div className='mb-8 text-center'>
-              <h2 className='mb-2 text-3xl font-bold text-slate-800'>
-                欢迎使用 OnlyWrite
-              </h2>
-              <p className='text-slate-500'>
-                简洁而强大的桌面写作应用，让您专注于内容创作
-              </p>
-            </div>
-
-            <div className='grid grid-cols-1 gap-6 sm:grid-cols-2'>
-              {/* 功能卡片 */}
-              <div className='rounded-lg border border-slate-200 bg-white p-6 shadow-sm'>
-                <div className='mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-50 text-blue-600'>
-                  <svg
-                    className='h-6 w-6'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                    stroke='currentColor'
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      d='M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z'
-                    />
-                  </svg>
-                </div>
-                <h3 className='mb-2 text-lg font-medium text-slate-800'>
-                  新建文档
-                </h3>
-                <p className='mb-4 text-sm text-slate-500'>
-                  开始一个全新的写作项目，记录您的想法和创意
-                </p>
-                <Button className='w-full'>创建文档</Button>
-              </div>
-
-              <div className='rounded-lg border border-slate-200 bg-white p-6 shadow-sm'>
-                <div className='mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-amber-50 text-amber-600'>
-                  <svg
-                    className='h-6 w-6'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                    stroke='currentColor'
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      d='M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253'
-                    />
-                  </svg>
-                </div>
-                <h3 className='mb-2 text-lg font-medium text-slate-800'>
-                  学习教程
-                </h3>
-                <p className='mb-4 text-sm text-slate-500'>
-                  查看使用指南，掌握 OnlyWrite 的全部功能
-                </p>
-                <Button variant='outline' className='w-full'>
-                  查看教程
-                </Button>
-              </div>
-            </div>
-
-            <div className='mt-8 rounded-lg border border-slate-200 bg-white p-6 shadow-sm'>
-              <h3 className='mb-4 text-lg font-medium text-slate-800'>
-                快速开始
-              </h3>
-              <div className='space-y-3'>
-                <Button variant='secondary' className='w-full justify-start'>
-                  <svg
-                    className='mr-2 h-5 w-5'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                    stroke='currentColor'
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      d='M15 12a3 3 0 11-6 0 3 3 0 016 0z'
-                    />
-                    <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      d='M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z'
-                    />
-                  </svg>
-                  浏览模板库
-                </Button>
-                <Button variant='secondary' className='w-full justify-start'>
-                  <svg
-                    className='mr-2 h-5 w-5'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                    stroke='currentColor'
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      d='M8 7v8a2 2 0 002 2h6M8 7V5a2 2 0 012-2h4.586a1 1 0 01.707.293l4.414 4.414a1 1 0 01.293.707V15a2 2 0 01-2 2h-2M8 7H6a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2v-2'
-                    />
-                  </svg>
-                  导入现有文档
-                </Button>
-                <Button variant='link' className='w-full justify-start'>
-                  <svg
-                    className='mr-2 h-5 w-5'
-                    fill='none'
-                    viewBox='0 0 24 24'
-                    stroke='currentColor'
-                    strokeWidth={2}
-                  >
-                    <path
-                      strokeLinecap='round'
-                      strokeLinejoin='round'
-                      d='M11 16l-4-4m0 0l4-4m-4 4h14m-5 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h7a3 3 0 013 3v1'
-                    />
-                  </svg>
-                  <a href='./login'>登录您的账户</a>
-                </Button>
-              </div>
-            </div>
-          </div>
+        <main className='flex-1 flex flex-col overflow-hidden'>
+          <ResizablePanelGroup direction='horizontal' className='flex-1'>
+            <ResizablePanel defaultSize={25} minSize={15}>
+              <FileArea />
+            </ResizablePanel>
+            <ResizableHandle withHandle />
+            <ResizablePanel defaultSize={75} minSize={30}>
+              <WritingArea />
+            </ResizablePanel>
+          </ResizablePanelGroup>
         </main>
       </div>
 

--- a/components/file-area.tsx
+++ b/components/file-area.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+export function FileArea() {
+  const dummyFiles = [
+    'document1.md',
+    'notes.txt',
+    'project-ideas.docx',
+    'research-paper.pdf',
+    'image.png',
+  ];
+
+  return (
+    <div className='flex h-full flex-col rounded-md border border-slate-200 bg-white p-4 shadow-sm'>
+      <h2 className='mb-4 text-lg font-semibold text-slate-700'>File Area</h2>
+      <ul className='space-y-1 overflow-y-auto'>
+        {dummyFiles.map((fileName, index) => (
+          <li
+            key={index}
+            className='cursor-pointer rounded-md px-3 py-2 text-sm text-slate-600 hover:bg-slate-50 hover:text-slate-800'
+          >
+            {fileName}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/writing-area.tsx
+++ b/components/writing-area.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+export function WritingArea() {
+  return (
+    <div className='flex h-full flex-col rounded-md border border-slate-200 bg-white p-4 shadow-sm'>
+      <h2 className='mb-4 text-lg font-semibold text-slate-700'>Writing Area</h2>
+      <textarea
+        className='flex-1 resize-none rounded-md border border-slate-300 p-3 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500'
+        placeholder='Start writing here...'
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
This commit introduces the initial design for the main application interface.

Key changes:
- Modified `app/page.tsx` to implement a resizable two-panel layout.
  - The left panel is designated for file navigation.
  - The right panel is designated for the writing/editing area.
- Created `components/file-area.tsx`:
  - A placeholder component for displaying files and folders.
  - Includes basic styling and a scrollable list of dummy files.
- Created `components/writing-area.tsx`:
  - A placeholder component for text editing.
  - Includes a textarea that fills the available space and basic styling.
- Integrated these new components into the main page layout.
- Removed the previous welcome message and feature cards from the main content area.